### PR TITLE
Allow undefined API key in type definition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ class Stripe {
       params: RealStripe.RefundCreateParams
     ) => Promise<RealStripe.Response<RealStripe.Refund>>;
   };
-  constructor(apiKey: string, config: RealStripe.StripeConfig) {
+  constructor(apiKey: string | undefined, config: RealStripe.StripeConfig) {
     this.customers = {
       async list(params) {
         await simulateNetworkLatency();


### PR DESCRIPTION
We already do allow it, but our types don't say so. This is technically a slight deviation from the actual Stripe SDK, but it's more honest (and avoids an error in our own example setup).

Fixes:
```
[0]  ERROR(TypeScript)  Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
[0]   Type 'undefined' is not assignable to type 'string'.
[0]  FILE  /Users/jacob/projects/interval2/web/src/pages/docs/get-started/assets/codeSnippets/index/typescript/payments.ts:8:27
[0]
[0]      6 | import 'dotenv/config';
[0]      7 |
[0]   >  8 | const stripe = new Stripe(process.env.STRIPE_KEY, {
[0]        |                           ^^^^^^^^^^^^^^^^^^^^^^
[0]      9 |   apiVersion: '2020-08-27',
[0]     10 | });
[0]     11 |
[0]
[0] Found 1 error. Watching for file changes.
```